### PR TITLE
observability: consolidate errors to use single measure but tagkeys

### DIFF
--- a/installJar.sh
+++ b/installJar.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+mvn install:install-file -Dfile=$(pwd)/target/jedis-3.0.0-SNAPSHOT.jar \
+-DgroupId=redis.clients -DartifactId=jedis -Dversion=3.0.0 \
+-Dpackaging=jar -DgeneratePom=true


### PR DESCRIPTION
Consolidate the various errors to use one single measure `MErrors`
However, provide various tag keys to discern them e.g.
* command -- the name of the command e.g. "getMany", "read", "ttl"
* phase   -- the part of the command e.g. "read", "flush"
* enum    -- an enumeration to distinguish a part e.g. "has_prefix"

This now gives the following visualizations:
<img width="419" alt="screen shot 2018-07-12 at 9 40 11 pm" src="https://user-images.githubusercontent.com/4898263/42671372-e2007912-861c-11e8-9a38-13d5531616f3.png">
<img width="1397" alt="screen shot 2018-07-12 at 9 40 21 pm" src="https://user-images.githubusercontent.com/4898263/42671371-e1ed7632-861c-11e8-87b0-a6de974e12c6.png">
<img width="378" alt="screen shot 2018-07-12 at 9 40 30 pm" src="https://user-images.githubusercontent.com/4898263/42671370-e1d96f8e-861c-11e8-93af-7e7c17b74555.png">
<img width="1385" alt="screen shot 2018-07-12 at 9 40 41 pm" src="https://user-images.githubusercontent.com/4898263/42671369-e1c6c8d4-861c-11e8-8c83-26d6b511827f.png">

